### PR TITLE
Update from vscode trace extension - prettier v3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ git remote add traceviewer-libs git@github.com:eclipse-cdt-cloud/traceviewer-lib
 # assumption: remote for official repo is named "origin"
 git checkout master && git pull origin master
 # push the latest local library changes to the git subtree upstream:
-git subtree push -p <subtree folder> <subtree remote repo> <remote review branch>
+git subtree push --prefix <subtree folder> <subtree remote repo> <remote review branch>
 # more concrete example: 
-git subtree push -p local-libs/traceviewer-libs traceviewer-libs update-from-vscode-trace-extension
+git subtree push --prefix local-libs/traceviewer-libs traceviewer-libs update-from-vscode-trace-extension
 
 # Then create a PR from the freshly pushed branch "update-from-vscode-trace-extension".
 # If tweaks are necessary, e.g. to remove some changes that are only relevant to 

--- a/base/.eslintrc.js
+++ b/base/.eslintrc.js
@@ -13,9 +13,10 @@ module.exports = {
     },
     extends: [
         'plugin:@typescript-eslint/recommended',
-        '../../configs/base.eslintrc.json',
-        '../../configs/warnings.eslintrc.json',
-        '../../configs/errors.eslintrc.json'
+        '../../../configs/base.eslintrc.json',
+        '../../../configs/warnings.eslintrc.json',
+        '../../../configs/errors.eslintrc.json',
+        "prettier"
     ],
     ignorePatterns: [
         'node_modules',

--- a/base/package.json
+++ b/base/package.json
@@ -34,7 +34,6 @@
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
         "test": "echo 'test'",
-        "watch": "tsc -w",
         "format:write": "prettier --write ./src",
         "format:check": "prettier --check ./src"
     }

--- a/base/package.json
+++ b/base/package.json
@@ -25,6 +25,7 @@
         "eslint-plugin-import": "^2.21.2",
         "eslint-plugin-no-null": "^1.0.2",
         "eslint-plugin-react": "^7.20.0",
+        "prettier": "^3.6.2",
         "rimraf": "^5.0.0",
         "typescript": "4.9.5"
     },

--- a/react-components/.eslintrc.js
+++ b/react-components/.eslintrc.js
@@ -17,9 +17,10 @@ module.exports = {
     extends: [
         'plugin:react/recommended',
         'plugin:@typescript-eslint/recommended',
-        '../../configs/base.eslintrc.json',
-        '../../configs/warnings.eslintrc.json',
-        '../../configs/errors.eslintrc.json'
+        '../../../configs/base.eslintrc.json',
+        '../../../configs/warnings.eslintrc.json',
+        '../../../configs/errors.eslintrc.json',
+        "prettier"
     ],
     ignorePatterns: [
         'node_modules',

--- a/react-components/package.json
+++ b/react-components/package.json
@@ -44,6 +44,7 @@
         "@types/d3": "^7.1.0",
         "@types/jest": "^28.0.0",
         "@types/lodash": "^4.14.142",
+        "@types/lodash.debounce": "4.0.3",
         "@types/react-grid-layout": "^1.1.1",
         "@types/react-modal": "^3.8.2",
         "@types/react-test-renderer": "^18.3.0",
@@ -57,6 +58,7 @@
         "jest": "^28.1.3",
         "jest-canvas-mock": "^2.4.0",
         "jest-environment-jsdom": "^28.1.3",
+        "prettier": "^3.6.2",
         "react-test-renderer": "^18.2.0",
         "rimraf": "^5.0.0",
         "ts-jest": "^28.0.8",
@@ -68,7 +70,6 @@
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
         "test": "jest  --config jest.config.json",
-        "watch": "tsc -b -w",
         "format:write": "prettier --write ./src",
         "format:check": "prettier --check ./src"
     }

--- a/react-components/src/components/abstract-gantt-output-component.tsx
+++ b/react-components/src/components/abstract-gantt-output-component.tsx
@@ -537,8 +537,8 @@ export abstract class AbstractGanttOutputComponent<
         return this.state.markerCategoryEntries.length <= 1
             ? 0
             : this.state.collapsedMarkerNodes.length
-            ? rowHeight
-            : this.state.markerCategoryEntries.length * rowHeight + scrollbarHeight;
+              ? rowHeight
+              : this.state.markerCategoryEntries.length * rowHeight + scrollbarHeight;
     }
 
     abstract renderTree(): React.ReactNode;

--- a/react-components/src/components/abstract-xy-output-component.tsx
+++ b/react-components/src/components/abstract-xy-output-component.tsx
@@ -383,12 +383,12 @@ export abstract class AbstractXYOutputComponent<
             d >= 1000000000000
                 ? Math.round(d / 100000000000) / 10 + 'G'
                 : d >= 1000000000
-                ? Math.round(d / 100000000) / 10 + 'B'
-                : d >= 1000000
-                ? Math.round(d / 100000) / 10 + 'M'
-                : d >= 1000
-                ? Math.round(d / 100) / 10 + 'K'
-                : Math.round(d * 10) / 10;
+                  ? Math.round(d / 100000000) / 10 + 'B'
+                  : d >= 1000000
+                    ? Math.round(d / 100000) / 10 + 'M'
+                    : d >= 1000
+                      ? Math.round(d / 100) / 10 + 'K'
+                      : Math.round(d * 10) / 10;
 
         if (this.state.allMax > 0) {
             select(this.yAxisRef.current)

--- a/react-components/src/components/data-providers/tsp-data-provider.ts
+++ b/react-components/src/components/data-providers/tsp-data-provider.ts
@@ -197,7 +197,7 @@ export class TspDataProvider {
                         start: arrow.start - offset,
                         end: arrow.end - offset
                     } as TimelineChart.TimeGraphRange
-                } as TimelineChart.TimeGraphArrow)
+                }) as TimelineChart.TimeGraphArrow
         );
         return arrows;
     }

--- a/react-components/src/components/utils/xy-output-component-utils.tsx
+++ b/react-components/src/components/utils/xy-output-component-utils.tsx
@@ -130,9 +130,9 @@ export function drawSelection(params: DrawSelectionParams): void {
     const { startPixel, endPixel, isBarPlot, chartArea, props, ctx, invertSelection } = params;
     const minPixel = Math.min(startPixel, endPixel);
     const maxPixel = Math.max(startPixel, endPixel);
-    const initialPoint = isBarPlot ? 0 : chartArea?.left ?? 0;
+    const initialPoint = isBarPlot ? 0 : (chartArea?.left ?? 0);
     const chartHeight = parseInt(props.style.height.toString());
-    const finalPoint = isBarPlot ? chartHeight : chartArea?.bottom ?? 0;
+    const finalPoint = isBarPlot ? chartHeight : (chartArea?.bottom ?? 0);
 
     if (ctx) {
         ctx.save();

--- a/react-components/src/components/xy-output-component.tsx
+++ b/react-components/src/components/xy-output-component.tsx
@@ -185,9 +185,9 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
     ) {
         const minPixel = Math.min(startPixel, endPixel);
         const maxPixel = Math.max(startPixel, endPixel);
-        const initialPoint = this.isBarPlot ? 0 : chartArea?.left ?? 0;
+        const initialPoint = this.isBarPlot ? 0 : (chartArea?.left ?? 0);
         const chartHeight = parseInt(this.props.style.height.toString());
-        const finalPoint = this.isBarPlot ? chartHeight : chartArea?.bottom ?? 0;
+        const finalPoint = this.isBarPlot ? chartHeight : (chartArea?.bottom ?? 0);
         if (ctx) {
             ctx.save();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide:https://github.com/eclipse-cdt-cloud/traceviewer-libs/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Updates "traceviewer-libs" from repo `eclipse-cdt-cloud/vscode-trace-extension`. The update contains little changes that were made after the traceviewer libraries were added as a local git subtree:

- some library code needed update to respect prettier v3.x (v2.x was originally used)
- a couple of dependencies relied on what was being pulled in the repo - updated the libraries to pull/request their own version (prettier, @types/lodash, @types/lodash-debounce. This makes the libraries less reliant to whatever version of these dependencies happen to be used in the host repo. There will probably be more to similarly adjust in the future, e.g. if/when they cause an issue.
- some configuration files in the host repo root are accessed relatively (e.g. `../../../<cfg_file>`) and need adjusting for the new library folder that's one level deeper vs before (works as updated in in both theia-trace-extension and vscode-trace-extension)

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Confirm that CI passes

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
